### PR TITLE
Upgrade Twitter integration to v2 and disable it

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "session-file-store": "^1.5.0",
     "siwe": "^0.1.2",
     "slugify": "^1.6.4",
-    "twit": "^2.2.11",
-    "twitter-api-v2": "^1.9.1",
+    "twitter-api-v2": "^1.14.2",
     "typeorm": "^0.2.41"
   },
   "devDependencies": {

--- a/src/modules/twitter/twitter.module.ts
+++ b/src/modules/twitter/twitter.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
 
 import { ClaimsModule } from '../claims/claims.module';
 import { SourcesModule } from '../sources/sources.module';
@@ -10,13 +11,12 @@ import { TwitterService } from './twitter.service';
 @Module({
   exports: [TwitterService],
   providers: [TwitterResolver, TwitterService],
-  imports: [ClaimsModule, UsersModule, SourcesModule, TagsModule],
+  imports: [ClaimsModule, UsersModule, SourcesModule, TagsModule, HttpModule],
 })
 export class TwitterModule {
   constructor(private readonly twitterService: TwitterService) {}
 
   configure() {
     // this.twitterService.startStream();
-    this.twitterService.startStreamV1();
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2782,7 +2782,7 @@ blockstore-core@^1.0.2:
     it-take "^1.0.1"
     multiformats "^9.4.7"
 
-bluebird@^3.1.5, bluebird@^3.5.0:
+bluebird@^3.5.0:
   version "3.7.2"
   resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -6693,7 +6693,7 @@ mime-types@^2.1.12, mime-types@^2.1.16, mime-types@^2.1.27, mime-types@~2.1.19, 
   dependencies:
     mime-db "1.51.0"
 
-mime@1.6.0, mime@^1.3.4:
+mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
@@ -7899,7 +7899,7 @@ regexpp@^3.2.0:
   resolved "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
-request@^2.68.0, request@^2.79.0:
+request@^2.79.0:
   version "2.88.2"
   resolved "https://registry.npmjs.org/request/-/request-2.88.2.tgz"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -8919,19 +8919,10 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-twit@^2.2.11:
-  version "2.2.11"
-  resolved "https://registry.npmjs.org/twit/-/twit-2.2.11.tgz"
-  integrity sha512-BkdwvZGRVoUTcEBp0zuocuqfih4LB+kEFUWkWJOVBg6pAE9Ebv9vmsYTTrfXleZGf45Bj5H3A1/O9YhF2uSYNg==
-  dependencies:
-    bluebird "^3.1.5"
-    mime "^1.3.4"
-    request "^2.68.0"
-
-twitter-api-v2@^1.9.1:
-  version "1.12.0"
-  resolved "https://registry.npmjs.org/twitter-api-v2/-/twitter-api-v2-1.12.0.tgz"
-  integrity sha512-8Fv+sUYY0P1gloiBSgG1w/NSuGUIP32lDKMPVzIMX3jd4zDhiJFtCft41fKs+JqcD8m7s+4vkMO/XwyY2+NULQ==
+twitter-api-v2@^1.14.2:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/twitter-api-v2/-/twitter-api-v2-1.14.2.tgz#d928eeb588f3a195a1db8059f0654b75d4278d3a"
+  integrity sha512-389e/rWaN8zWkmD5z2IpKVb5+ojPxVtrexQoGBI1Xfib1mE/9M7k7zbnZ3Q/WLwthwcWkQIlB25ecT64AL8LvQ==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Twitter API v1.1 has been deprecated making Fractal Flows server stop working and v2 is buggy returning 429 status codes for too many requests when none has been done in hours, so the Twitter bot integration has been disabled for now. More info about the Twitter API issue https://twittercommunity.com/t/rate-limit-on-tweets-stream-api/144389

As a workaround, we could be polling recent tweets every X minutes instead of connecting to a stream to try to circumvent the rate limit issue described above.